### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Alternatively, a fully functional implementation of the protocol is available in
 [liquidsoap](https://github.com/savonet/liquidsoap). To test it, you can simply run liquidsoap with the following
 command line:
 ```
-liquidsoap 'output.ao(fallible=true,audio_to_stereo(input.harbor("mount",port=8080)))'
+liquidsoap "output.ao(fallible=true,audio_to_stereo(input.harbor('mount',port=8080)))"
 ```
 
 ### Webcast.js API


### PR DESCRIPTION
Reverse quotes on liquidsoap example, it doesn't seem to work the other way around.
